### PR TITLE
debug off by one in --help

### DIFF
--- a/spec/serializers/cli_tabular_serializer_spec.rb
+++ b/spec/serializers/cli_tabular_serializer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Foobara::CommandConnectors::ShCliConnector::Serializers::CliTabul
 
       it "serializes the table" do
         expect(result).to eq(
-          "  foo- bar- bazbaz\n  foo  bar\n"
+          " foo- bar- bazbaz\n foo  bar\n"
         )
       end
     end

--- a/src/sh_cli_connector/serializers/cli_tabular_serialzier.rb
+++ b/src/sh_cli_connector/serializers/cli_tabular_serialzier.rb
@@ -43,7 +43,7 @@ module Foobara
 
               lines.each do |line|
                 if indent > 0
-                  line = (" " * indent) + line
+                  line = (" " * (indent-1)) + line
                 end
 
                 io.puts line.rstrip

--- a/src/sh_cli_connector/serializers/cli_tabular_serialzier.rb
+++ b/src/sh_cli_connector/serializers/cli_tabular_serialzier.rb
@@ -43,7 +43,7 @@ module Foobara
 
               lines.each do |line|
                 if indent > 0
-                  line = (" " * (indent-1)) + line
+                  line = (" " * (indent - 1)) + line
                 end
 
                 io.puts line.rstrip


### PR DESCRIPTION
this PR fixes the issue #5

The issue was with a variable called `indent` and it was off by one so padded the left of the line with `" " * (indent-1) `to make up for the off-by-one overflow of the line size.

I hope the typo in the file name doesn't matter.

Thanks for reviewing!!